### PR TITLE
Delayed starting the game until all players joined

### DIFF
--- a/server/admin/MatchManagement.js
+++ b/server/admin/MatchManagement.js
@@ -132,7 +132,8 @@ class MatchManager {
 			return { message: matchNotFound };
 		}
 
-		if (game.getRedField().id != "" && game.getRedSpy().id != "" && game.getBlueSpy().id != "" && game.getBlueField().id != "") {
+		if (game.getRedField().id && game.getRedSpy().id && game.getBlueSpy().id && game.getBlueField().id) {
+			game.reset();
 			return { gamestart: true, info: this.getMatchInfo(matchID, userID), message: mess };
 		}
 

--- a/server/engine/Game.js
+++ b/server/engine/Game.js
@@ -32,7 +32,7 @@ class Game {
 		this.redField = {};
 		this.blueField = {};
 		this.chatHistory = [];
-		this.reset();
+		this.board = new Board();
 	}
 
 	setHost(id) {
@@ -81,7 +81,6 @@ class Game {
 	//Function to restart game.
 	reset() {
 		this.state = gameState.RED_SPY;
-		this.board = new Board();
 		this.redLeft = 9;
 		this.blueLeft = 8;
 		this.numGuessesLeft = 0;


### PR DESCRIPTION
The backend timer starts immediately when a game was created, but it should only happen when all players have joined.